### PR TITLE
Update release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,15 +30,15 @@ jobs:
         name: "Login: DockerHub"
         uses: docker/login-action@v1 
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{secrets.DOCKERHUB_USERNAME}}
+          password: ${{secrets.DOCKERHUB_TOKEN}}
       - 
         name: "Login: GitHub Container Registry"
         uses: docker/login-action@v1 
         with:
           registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{github.repository_owner}}
+          password: ${{secrets.GITHUB_TOKEN}}
       - 
         id: generate-tag
         name: "Generate Version Tag"


### PR DESCRIPTION
Adds (experimental) support for pushing tags to Docker Hub.

For example, if publishing from the `main` branch, the tag will always be `:latest`. But if the workflow is running from a push on the branch `next`, it will be tagged `next`. Also, if its a tag or release that triggers the run, it will be published under the appropriate `ref_name`.

Files changed:

- [x] `./.github/workflows/release.yml`

<a href="https://gitpod.io/#https://github.com/nberlette/gitpod-enhanced/pull/11"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

